### PR TITLE
Update build instructions to reflect recent packer changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 $ make
 
 # Build all images
-$ packer build xnat-web.pkr.hcl
+$ packer build .
 
 # Build an individual image
-$ packer build -only docker.xnat17 xnat-web.pkr.hcl
+$ packer build -only docker.xnat-web .
 
 # Build all docker images
-$ packer build -only docker.* xnat-web.pkr.hcl
-```
+$ packer build -only docker.* .
 
-Reference:
-* https://bitbucket.org/xnatdev/container-service/downloads/
+# Build the xnat-web docker image with an overridden uid
+$ packer build -var "run_as_uid=997" -only docker.xnat-web .
+```


### PR DESCRIPTION
Given the changes in 20840f8c508389cc7e33c819c63fdcaceff082a7 as well as the deprecation of XNAT 1.7, it's necessary to update the build instructions.

We can no longer specify the HCL file in the packer build command because of the split into a separate variables file - see https://github.com/hashicorp/packer/issues/10127