### PR TITLE
Allow override of destination Docker registry

### DIFF
--- a/xnat-web-variables.pkr.hcl
+++ b/xnat-web-variables.pkr.hcl
@@ -34,6 +34,7 @@ variable "docker_image" {
   type = string
 }
 variable "repository" {
-  default = "ghcr.io/australian-imaging-service"
+  # Do not change default - required for CI/CD pipeline
+  default = "localhost:32000"
   type = string
 }

--- a/xnat-web.pkr.hcl
+++ b/xnat-web.pkr.hcl
@@ -61,11 +61,10 @@ build {
   }
 
   post-processors {
-    # Do not remove
-    # repository and ci tag required for CICD pipeline
-    # used for development; microk8s registery
+    # Do not remove ci tag - required for CICD pipeline
+    # used for development; microk8s registry
     post-processor "docker-tag" {
-      repository =  "localhost:32000/${source.name}"
+      repository =  "${var.repository}/${source.name}"
       tags = ["${var.xnat_version}","ci"]
       only = ["docker.xnat-web"]
     }


### PR DESCRIPTION
Some organisations will want to build their docker image themselves (e.g. so they can set the UID) but don't want to install/tag the resulting image into a registry running on ``localhost:32000``

This PR adds the ability for it to be overwritten at packer buildtime but without (hopefully) breaking the CI/CD chain on GitHub.

The existing ``repository`` packer variable does not seem to be used - so I have repurposed that.